### PR TITLE
Add profile popover with logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import AdminLayout from './layout/AdminLayout'
 import styles from './App.module.scss'
 import Dashboard from './pages/Dashboard'
@@ -6,20 +6,27 @@ import Profile from './pages/Profile'
 import Products from './pages/Products'
 import Users from './pages/Users'
 import Orders from './pages/Orders'
+import Login from './pages/Login'
+import { useAppSelector } from './store/hooks'
 
 export default function App() {
+  const loggedIn = useAppSelector((s) => s.auth.loggedIn)
+
   return (
     <BrowserRouter>
       <div className={styles.app}>
-      <Routes>
-        <Route path="/" element={<AdminLayout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="profile" element={<Profile />} />
-          <Route path="products" element={<Products />} />
-          <Route path="users" element={<Users />} />
-          <Route path="orders" element={<Orders />} />
-        </Route>
-      </Routes>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/"
+            element={loggedIn ? <AdminLayout /> : <Navigate to="/login" replace />}>
+            <Route index element={<Dashboard />} />
+            <Route path="profile" element={<Profile />} />
+            <Route path="products" element={<Products />} />
+            <Route path="users" element={<Users />} />
+            <Route path="orders" element={<Orders />} />
+          </Route>
+        </Routes>
       </div>
     </BrowserRouter>
   )

--- a/src/layout/AdminLayout.module.scss
+++ b/src/layout/AdminLayout.module.scss
@@ -20,6 +20,12 @@
   padding: 0 16px;
   line-height: 64px;
   border-bottom: 1px solid #f0f0f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.avatar {
+  cursor: pointer;
 }
 .content {
   margin: 24px;

--- a/src/layout/AdminLayout.tsx
+++ b/src/layout/AdminLayout.tsx
@@ -1,11 +1,22 @@
-import { Layout, Menu } from 'antd'
-import { Link, Outlet, useLocation } from 'react-router-dom'
+import { Layout, Menu, Avatar, Popover, Button } from 'antd'
+import { Link, Outlet, useLocation, Navigate } from 'react-router-dom'
+import { UserOutlined } from '@ant-design/icons'
+import { useAppDispatch, useAppSelector } from '../store/hooks'
+import { logout } from '../store/store'
 import styles from './AdminLayout.module.scss'
 
 const { Header, Content, Footer, Sider } = Layout
 
 export default function AdminLayout() {
   const location = useLocation()
+  const dispatch = useAppDispatch()
+  const loggedIn = useAppSelector((s) => s.auth.loggedIn)
+
+  const handleLogout = () => {
+    dispatch(logout())
+  }
+
+  if (!loggedIn) return <Navigate to="/login" replace />
 
   return (
     <Layout className={styles.layout}>
@@ -25,7 +36,16 @@ export default function AdminLayout() {
         />
       </Sider>
       <Layout>
-        <Header className={styles.header}>Admin Panel</Header>
+        <Header className={styles.header}>
+          <div>Admin Panel</div>
+          <Popover
+            trigger="click"
+            placement="bottomRight"
+            content={<Button type="text" onClick={handleLogout}>Logout</Button>}
+          >
+            <Avatar className={styles.avatar} icon={<UserOutlined />} />
+          </Popover>
+        </Header>
         <Content className={styles.content}>
           <Outlet />
         </Content>

--- a/src/pages/Login.module.scss
+++ b/src/pages/Login.module.scss
@@ -1,0 +1,5 @@
+.login {
+  h1 {
+    margin-bottom: 16px;
+  }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,28 @@
+import { Button, Form, Input } from 'antd'
+import { useAppDispatch } from '../store/hooks'
+import { login } from '../store/store'
+import styles from './Login.module.scss'
+
+export default function Login() {
+  const dispatch = useAppDispatch()
+  const onFinish = () => {
+    dispatch(login())
+  }
+
+  return (
+    <div className={styles.login}>
+      <h1>Login</h1>
+      <Form onFinish={onFinish} layout="vertical" style={{ maxWidth: 300 }}>
+        <Form.Item label="Email" name="email">
+          <Input />
+        </Form.Item>
+        <Form.Item label="Password" name="password">
+          <Input.Password />
+        </Form.Item>
+        <Button type="primary" htmlType="submit">
+          Login
+        </Button>
+      </Form>
+    </div>
+  )
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -137,6 +137,25 @@ const profileSlice = createSlice<Profile>({
 
 export const { updateProfile } = profileSlice.actions
 
+export interface AuthState {
+  loggedIn: boolean
+}
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: { loggedIn: true } as AuthState,
+  reducers: {
+    login: (state) => {
+      state.loggedIn = true
+    },
+    logout: (state) => {
+      state.loggedIn = false
+    },
+  },
+})
+
+export const { login, logout } = authSlice.actions
+
 export const store = configureStore({
   reducer: {
     counter: counterSlice.reducer,
@@ -144,6 +163,7 @@ export const store = configureStore({
     users: usersSlice.reducer,
     orders: ordersSlice.reducer,
     profile: profileSlice.reducer,
+    auth: authSlice.reducer,
   },
 })
 


### PR DESCRIPTION
## Summary
- implement `auth` slice for basic login state
- add login page to toggle auth state
- show login guard in routing
- display profile avatar with logout popover in admin header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6882446c32a88332bb8695c605517e19