### PR TITLE
Improve login flow with hook form

### DIFF
--- a/src/pages/Login.module.scss
+++ b/src/pages/Login.module.scss
@@ -1,5 +1,33 @@
 .login {
-  h1 {
-    margin-bottom: 16px;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .form {
+    background: #fff;
+    padding: 32px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    width: 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    h1 {
+      margin: 0 0 8px;
+      text-align: center;
+    }
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .error {
+    color: #ff4d4f;
+    font-size: 12px;
+    margin-top: 4px;
   }
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,28 +1,51 @@
-import { Button, Form, Input } from 'antd'
+import { Button, Input } from 'antd'
+import { useForm } from 'react-hook-form'
 import { useAppDispatch } from '../store/hooks'
 import { login } from '../store/store'
+import { useNavigate } from 'react-router-dom'
 import styles from './Login.module.scss'
+
+interface LoginForm {
+  email: string
+  password: string
+}
 
 export default function Login() {
   const dispatch = useAppDispatch()
-  const onFinish = () => {
+  const navigate = useNavigate()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginForm>()
+
+  const onSubmit = async () => {
+    // simulate async login request
+    await new Promise((resolve) => setTimeout(resolve, 500))
     dispatch(login())
+    navigate('/', { replace: true })
   }
 
   return (
     <div className={styles.login}>
-      <h1>Login</h1>
-      <Form onFinish={onFinish} layout="vertical" style={{ maxWidth: 300 }}>
-        <Form.Item label="Email" name="email">
-          <Input />
-        </Form.Item>
-        <Form.Item label="Password" name="password">
-          <Input.Password />
-        </Form.Item>
-        <Button type="primary" htmlType="submit">
+      <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+        <h1>Login</h1>
+        <label className={styles.field}>
+          Email
+          <Input {...register('email', { required: true })} />
+          {errors.email && <span className={styles.error}>Email is required</span>}
+        </label>
+        <label className={styles.field}>
+          Password
+          <Input.Password {...register('password', { required: true })} />
+          {errors.password && (
+            <span className={styles.error}>Password is required</span>
+          )}
+        </label>
+        <Button type="primary" htmlType="submit" loading={isSubmitting} block>
           Login
         </Button>
-      </Form>
+      </form>
     </div>
   )
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -143,7 +143,8 @@ export interface AuthState {
 
 const authSlice = createSlice({
   name: 'auth',
-  initialState: { loggedIn: true } as AuthState,
+  // start the app logged out so the login flow can be tested
+  initialState: { loggedIn: false } as AuthState,
   reducers: {
     login: (state) => {
       state.loggedIn = true


### PR DESCRIPTION
## Summary
- use `react-hook-form` and Antd inputs for login form
- add polished login styles
- start store with `loggedIn: false` and redirect to dashboard on fake login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688247ad548883328390dcfdd6fb3666