### PR TITLE
Move profile link to header and update profile page

### DIFF
--- a/src/layout/AdminLayout.module.scss
+++ b/src/layout/AdminLayout.module.scss
@@ -37,3 +37,8 @@
   padding: 16px;
   background: #f0f0f0;
 }
+
+.popover {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/layout/AdminLayout.tsx
+++ b/src/layout/AdminLayout.tsx
@@ -28,7 +28,6 @@ export default function AdminLayout() {
           selectedKeys={[location.pathname]}
           items={[
             { key: '/', label: <Link to="/">Dashboard</Link> },
-            { key: '/profile', label: <Link to="/profile">Profile</Link> },
             { key: '/products', label: <Link to="/products">Products</Link> },
             { key: '/users', label: <Link to="/users">Users</Link> },
             { key: '/orders', label: <Link to="/orders">Orders</Link> },
@@ -40,7 +39,16 @@ export default function AdminLayout() {
           <Popover
             trigger="click"
             placement="bottomRight"
-            content={<Button type="text" onClick={handleLogout}>Logout</Button>}
+            content={
+              <div className={styles.popover}>
+                <Button type="text">
+                  <Link to="/profile">Profile</Link>
+                </Button>
+                <Button type="text" onClick={handleLogout}>
+                  Logout
+                </Button>
+              </div>
+            }
           >
             <Avatar className={styles.avatar} icon={<UserOutlined />} />
           </Popover>

--- a/src/pages/Profile.module.scss
+++ b/src/pages/Profile.module.scss
@@ -1,7 +1,23 @@
 .page {
+  display: flex;
+  justify-content: center;
+  padding-top: 24px;
+
+  .card {
+    background: #fff;
+    padding: 32px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    width: 400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   h1 {
     margin-bottom: 16px;
   }
+
   .avatar {
     width: 80px;
     height: 80px;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -8,6 +8,8 @@ interface FormValues {
   name: string
   email: string
   password: string
+  phone: string
+  address: string
 }
 
 export default function Profile() {
@@ -21,22 +23,30 @@ export default function Profile() {
 
   return (
     <div className={styles.page}>
-      <h1>Profile</h1>
-      <img className={styles.avatar} src="https://i.pravatar.cc/80" alt="avatar" />
-      <Form onFinish={handleSubmit(onSubmit)} layout="vertical" style={{ maxWidth: 400 }}>
-        <Form.Item label="Name">
-          <Input {...register('name', { required: true })} />
-        </Form.Item>
-        <Form.Item label="Email">
-          <Input {...register('email', { required: true })} />
-        </Form.Item>
-        <Form.Item label="Password">
-          <Input.Password {...register('password')} />
-        </Form.Item>
-        <Button type="primary" htmlType="submit">
-          Save
-        </Button>
-      </Form>
+      <div className={styles.card}>
+        <h1>Profile</h1>
+        <img className={styles.avatar} src="https://i.pravatar.cc/80" alt="avatar" />
+        <Form onFinish={handleSubmit(onSubmit)} layout="vertical" style={{ width: '100%' }}>
+          <Form.Item label="Name">
+            <Input {...register('name', { required: true })} />
+          </Form.Item>
+          <Form.Item label="Email">
+            <Input {...register('email', { required: true })} />
+          </Form.Item>
+          <Form.Item label="Phone">
+            <Input {...register('phone')} />
+          </Form.Item>
+          <Form.Item label="Address">
+            <Input {...register('address')} />
+          </Form.Item>
+          <Form.Item label="Password">
+            <Input.Password {...register('password')} />
+          </Form.Item>
+          <Button type="primary" htmlType="submit" block>
+            Save
+          </Button>
+        </Form>
+      </div>
     </div>
   )
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -124,11 +124,19 @@ export interface Profile {
   name: string
   email: string
   password: string
+  phone: string
+  address: string
 }
 
 const profileSlice = createSlice<Profile>({
   name: 'profile',
-  initialState: { name: 'Admin', email: 'admin@example.com', password: '' } as Profile,
+  initialState: {
+    name: 'Admin',
+    email: 'admin@example.com',
+    password: '',
+    phone: '',
+    address: '',
+  } as Profile,
   reducers: {
     updateProfile: (_state: Profile, action: PayloadAction<Profile>) =>
       action.payload,


### PR DESCRIPTION
## Summary
- remove Profile from sidebar
- add Profile button to header popover
- keep logout in header popover
- style popover container
- upgrade profile store with phone and address fields
- enhance Profile page UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68824f87257483328a3c6c0a55f7e13d